### PR TITLE
Don’t redirect legacy embed URLs, analytics

### DIFF
--- a/open-in-client.js
+++ b/open-in-client.js
@@ -8,9 +8,10 @@ var urls = {
 chrome.webRequest.onBeforeRequest.addListener(function(details) {
   var domainEnds = details.url.indexOf('/', 8) + 1, // https://.length == 8
       uriPart = details.url.slice(domainEnds).replace(/\//g, ':'),
-      isEmbedLink = details.url.indexOf('/embed/') != -1;
+      isAnalytics = details.url.indexOf('/log/') !== -1,
+      isEmbedLink = details.url.match(/\/embed[?/]/) !== null;
 
-  if(uriPart && !isEmbedLink) {
+  if(uriPart && !isAnalytics && !isEmbedLink) {
     // If the current tab url is the same as the one initiating this
     // request it means this is a newly opened tab, so it is safe to
     // close the tab after Spotify has been opened.


### PR DESCRIPTION
This PR prevents the redirect in the following cases:

- Legacy embedding syntax `https://open.spotify.com/embed?uri=SPOTIFYURL`, which is still occasionally used ([example URL](https://open.spotify.com/embed?uri=spotify:track:6vNrUkbSCj9pvqrdgJi2bF); [example page with embedded content](https://web.archive.org/web/20181118223513/http://jethrotull.com/))

- Asynchronous POST requests to Spotify’s analytics API (`https://open.spotify.com/log/analytics`); this happens e. g. when you visit an embed URL (see above) directly in the browser. It may happen on other occasions though.
